### PR TITLE
Import skimage submodules to account for 'lazy importing'

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -2,7 +2,8 @@
 from pathlib import Path
 import imageio as iio
 import numpy as np
-import skimage
+import skimage.exposure
+import skimage.util
 
 
 def get_imgs(


### PR DESCRIPTION
Explicitly import submodules